### PR TITLE
filemanag_zenodo(): bugfixes docu syntax in title & description

### DIFF
--- a/n2khabutils/R/filemanagement.R
+++ b/n2khabutils/R/filemanagement.R
@@ -81,9 +81,9 @@ filemanag_folders <- function(root = c("rproj", "git"), path = NA) {
 
 
 
-#' @title Get raw data from a zenodo archive
+#' Get raw data from a Zenodo archive
 #'
-#' This function will download data from Zenodo (\href{https://zenodo.org}).
+#' This function will download data from Zenodo (\url{https://zenodo.org}).
 #' It only works for Zenodo created DOI (not when the DOI is for
 #' example derived from Zookeys.)
 #'


### PR DESCRIPTION
These are fixes regarding my own commits from yesterday.

- either @title and @description and @details must be used, or none, it seems. (For the latter case, see [this](http://r-pkgs.had.co.nz/man.html#roxygen-comments) documentation)
- the \url command had to be used instead of \href