### PR TITLE
readme typo: fixed link to `n2khab-mne-monitoring`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Several functions return preprocessed datasets (see `n2khab-preprocessing`) as s
 - **[n2khab-samplingframes](https://github.com/inbo/n2khab-samplingframes)**: sampling frames and code to reproduce or update these.
 - **[n2khab-mne-designs](https://github.com/inbo/n2khab-mne-designs)**: design of the Flemish monitoring programme for the natural environment (MNE).
 - **[n2khab-sample-admin](https://github.com/inbo/n2khab-sample-admin)**: sample management and associated code.
-- **[n2khab-mne-monitoring](https://github.com/inbo/n2khab-mne-design)**: operational components of the Flemish monitoring programme for the natural environment (MNE).
+- **[n2khab-mne-monitoring](https://github.com/inbo/n2khab-mne-monitoring)**: operational components of the Flemish monitoring programme for the natural environment (MNE).
 - **[n2khab-mhq-design](https://github.com/inbo/n2khab-mhq-design)**: design of the Flemish monitoring programme for the biotic habitat quality (MHQ).
 - **[n2khab-mhq-data](https://github.com/inbo/n2khab-mhq-data)**: read fieldwork data collected in MHQ.
 - **[n2khab-mhq-analysis](https://github.com/inbo/n2khab-mhq-analysis)**


### PR DESCRIPTION
There was a wrong link on the front page (triv.).