### PR TITLE
add_dmp: add link to MNE DMP repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Several functions return preprocessed datasets (see `n2khab-preprocessing`) as s
 - **[n2khab-preprocessing](https://github.com/inbo/n2khab-preprocessing)**: provides workflows to generate processed data from raw data that are important to N2KHAB-projects.
 - **[n2khabmon](https://github.com/inbo/n2khabmon)**: R package to prepare and manage Flemish monitoring schemes regarding Natura 2000 habitats.
 - **[n2khab-samplingframes](https://github.com/inbo/n2khab-samplingframes)**: sampling frames and code to reproduce or update these.
+- **[n2khab-mne-dmp](https://github.com/inbo/n2khab-mne-dmp)**: data management plan (DMP) of the Flemish monitoring programme for the natural environment (MNE).
 - **[n2khab-mne-designs](https://github.com/inbo/n2khab-mne-designs)**: design of the Flemish monitoring programme for the natural environment (MNE).
 - **[mnedesigndata](https://github.com/inbo/mnedesigndata)**: R package to distribute and document R data objects that reflect the current implementation design of the Monitoring Programme for the Natural Environment (MNE).
 - **[n2khab-sample-admin](https://github.com/inbo/n2khab-sample-admin)**: sample management and associated code.


### PR DESCRIPTION
The trivial addition of a link to the newly created MNE DMP repo.